### PR TITLE
Update form.php

### DIFF
--- a/app/Views/form.php
+++ b/app/Views/form.php
@@ -51,9 +51,11 @@ $resultMessage = $resultMessage ?? '';
         <label>軒とい:
           <select name="nokiToiCode" id="nokiToiCode" required>
             <option value="">── 選択してください ──</option>
-            <!-- 適切な選択肢をここに追加 -->
-            <option value="N30" <?= $nokiToiCode === 'N30' ? 'selected' : '' ?>>メタリック調軒といサーフェスケアＦＳ−II型 / 108.7cm²</option>
-            <!-- 他の選択肢も同様に追加 -->
+            <?php foreach ($nokiToiList as $nokiToi): ?>
+              <option value="<?= $nokiToi->getNokiToiCode() ?>" <?= $nokiToiCode === $nokiToi->getNokiToiCode() ? 'selected' : '' ?>>
+                <?= htmlspecialchars($nokiToi->getNokiToiName()) ?> / <?= round($nokiToi->getA_Original(), 1) ?>cm²
+              </option>
+            <?php endforeach; ?>
           </select>
         </label>
         <label>屋根横幅 X (m):
@@ -109,9 +111,11 @@ $resultMessage = $resultMessage ?? '';
       <legend>縦とい選択</legend>
       <select name="tateToiCode" id="tateToiCode" required>
         <option value="">── 選択してください ──</option>
-        <!-- 適切な選択肢をここに追加 -->
-        <option value="T60" <?= $tateToiCode === 'T60' ? 'selected' : '' ?>>メタリック調たてとい60 / 26.6cm²</option>
-        <!-- 他の選択肢も同様に追加 -->
+        <?php foreach ($tateToiList as $tateToi): ?>
+          <option value="<?= $tateToi->getTateToiCode() ?>" <?= $tateToiCode === $tateToi->getTateToiCode() ? 'selected' : '' ?>>
+            <?= htmlspecialchars($tateToi->getTateToiSize()) ?> / <?= round($tateToi->getPrimeA_Original(), 1) ?>cm²
+          </option>
+        <?php endforeach; ?>
       </select>
     </fieldset>
 


### PR DESCRIPTION
## 🛠 PRタイトル：
軒とい（nokiToi）の選択肢を CSV 読み込みによる動的生成に対応

---

## 🔄 概要：
`form.php` における軒といの `<select>` 要素が、これまで固定選択肢1件のみだったのを、  
`CalculatorController.php` 経由で読み込まれる `nokiToiList` の内容から動的に生成するよう修正しました。

---

## ✅ 変更点詳細：

### 1. `form.php`
- `nokiToiCode` に対応する `<select>` を `foreach ($nokiToiList as $nokiToi)` により自動生成
- 表示名称として `getNokiToiName()` および `getA_Original()` を使用
- 既存の選択状態復元（`selected`）にも対応済み

### 2. `CalculatorController.php`
- `$nokiToiList = $this->csvLoader->loadNokiToiList();` の呼び出しは既存で対応済みのため、変更なし

---

## 🔍 動作確認済み：
- [x] CSV（nokitoi.csv）に登録された全ての軒といが選択肢に表示される
- [x] 前回選択値が POST により再表示される
- [x] フォーム送信後も軒といの値が正しく渡り、排水量計算が行われる

---

## 📌 注意点・未対応事項：
- 表示されるテキスト（形式：`製品名 / 面積cm²`）の整形ロジックはシンプルにしてあります
- 今後、メーカー名やアイコン表示などが必要になれば、テンプレート内でのUI改修が必要

---

## 👤 レビューお願い事項：
- 表示される軒とい選択肢の文言フォーマット
- `form.php` 側での復元ロジック（`selected`）の妥当性
